### PR TITLE
Handle artifacts which are already in GAR

### DIFF
--- a/lib/events/register_skill.ts
+++ b/lib/events/register_skill.ts
@@ -508,6 +508,10 @@ async function createArtifact(
 			ctx.data.image.repository.name.startsWith(
 				"atomist-container-skills/",
 			)) ||
+		(ctx.data.image.repository.host === "us-east1-docker.pkg.dev" &&
+			ctx.data.image.repository.name.startsWith(
+				"scout-artifact-registry/",
+			)) ||
 		(ctx.data.image.repository.host === "hub.docker.com" &&
 			ctx.data.image.repository.name.startsWith("atomist/"))
 	) {


### PR DESCRIPTION
This is a bit of a belt-and-braces job. I'm not sure how many skill artifacts we'll have which are already in GAR but I need a commit to re-register this skill (thus putting it into GAR itself) and I might as well make a vaguely useful change to do it!